### PR TITLE
feat: Add placeholder input parser

### DIFF
--- a/game_engine/input_parser.py
+++ b/game_engine/input_parser.py
@@ -1,0 +1,33 @@
+def parse_input(raw_text: str) -> str:
+    """
+    Parses the raw text input from the player.
+    
+    Currently, this function is a placeholder and simply returns the
+    raw text without any processing. Future implementations will
+    extract commands and arguments.
+
+    Args:
+        raw_text (str): The raw text input from the player.
+
+    Returns:
+        str: The processed command or the original text if no specific parsing is done.
+    """
+    # Placeholder implementation:
+    # In the future, this will involve more complex parsing logic,
+    # such as splitting into command and arguments, lowercasing, etc.
+    # For now, it just returns the input as is.
+    return raw_text
+
+if __name__ == '__main__':
+    # Example usage:
+    test_input1 = "look around"
+    parsed_output1 = parse_input(test_input1)
+    print(f"Input: '{test_input1}' -> Parsed: '{parsed_output1}'")
+
+    test_input2 = "GO NORTH"
+    parsed_output2 = parse_input(test_input2)
+    print(f"Input: '{test_input2}' -> Parsed: '{parsed_output2}'")
+    
+    test_input3 = "  examine sword  "
+    parsed_output3 = parse_input(test_input3) # Example of input that might be trimmed/normalized later
+    print(f"Input: '{test_input3}' -> Parsed: '{parsed_output3}'")

--- a/tests/test_input_parser.py
+++ b/tests/test_input_parser.py
@@ -1,0 +1,36 @@
+import unittest
+import sys
+import os
+
+# Add the parent directory to the Python path to allow importing from game_engine
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from game_engine.input_parser import parse_input
+
+class TestInputParser(unittest.TestCase):
+    """
+    Test suite for the parse_input function from input_parser.
+    """
+
+    def test_parse_input_returns_raw_text(self):
+        """
+        Tests if parse_input currently returns the raw text input unchanged.
+        This is because it's a placeholder function.
+        """
+        test_cases = [
+            "look north",
+            "GET SWORD",
+            "  examine chest  ",
+            "",
+            "a b c d e f g",
+            "12345",
+            "!@#$%^"
+        ]
+
+        for text_input in test_cases:
+            with self.subTest(input=text_input):
+                self.assertEqual(parse_input(text_input), text_input,
+                                 f"parse_input should return the raw text '{text_input}' but did not.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Created `game_engine/input_parser.py`.
- Defined a placeholder function `parse_input(raw_text: str) -> str`.
    - This function currently returns the `raw_text` directly.
    - Includes type hints and a docstring indicating it's a placeholder for future, more complex parsing logic.
- Added unit tests in `tests/test_input_parser.py`:
    - Created `TestInputParser` class.
    - Implemented `test_parse_input_returns_raw_text` which verifies that `parse_input` returns its input unchanged, using a variety of sample strings (including empty, spaced, and special character strings) via `self.subTest`.