### PR TITLE
feat: Connect UI input to GameManager command processing

### DIFF
--- a/game_engine/game_manager.py
+++ b/game_engine/game_manager.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from ui.ui_manager import GameUI
 from game_engine.persistence_service import setup_database
+from game_engine.input_parser import parse_input
 
 class GameManager:
     """
@@ -34,7 +35,7 @@ class GameManager:
 
         print("GameManager: Initializing UI...")
         self.root = tk.Tk()
-        self.ui = GameUI(self.root) # Create GameUI instance
+        self.ui = GameUI(self.root, self) # Pass GameManager instance to GameUI
         print("GameManager: UI initialized.")
 
     def start_game(self):
@@ -46,6 +47,28 @@ class GameManager:
             self.ui.start_ui()
         else:
             print("GameManager: Error - UI not initialized. Cannot start game.")
+
+    def process_player_command(self):
+        """
+        Retrieves player input from the UI, processes it, and displays feedback.
+        """
+        command_string = self.ui.get_player_input()
+        stripped_command = command_string.strip() # Get a stripped version once
+
+        if stripped_command: # Check if the stripped command is not empty
+            self.ui.add_story_text(f'You typed: {stripped_command}')
+            
+            # Call parse_input (already imported)
+            parsed_command = parse_input(stripped_command)
+            
+            # Placeholder for actual command processing logic
+            # For now, just acknowledge the parsed command (which is same as stripped_command)
+            # self.ui.add_story_text(f'Parsed as: {parsed_command}') # Optional debug line
+            
+            self.ui.add_story_text('The ancient echoes respond...')
+        # else:
+            # Optionally, handle empty input, e.g., self.ui.add_story_text("Please enter a command.")
+            # For now, empty input is silently ignored as per the conditional check.
 
 if __name__ == '__main__':
     # This block is for testing the GameManager independently.

--- a/tests/test_game_manager.py
+++ b/tests/test_game_manager.py
@@ -31,15 +31,15 @@ class TestGameManager(unittest.TestCase):
         mock_os_path_exists.return_value = True
 
         # Instantiate GameManager
-        game_manager = GameManager()
+        game_manager = GameManager() # This is the instance we need to pass
 
         # Assertions
         mock_os_path_exists.assert_called_once_with('data')
         mock_setup_database.assert_called_once()
         mock_tk_class.assert_called_once()
         
-        # GameUI should be initialized with the instance returned by tk.Tk()
-        mock_game_ui_class.assert_called_once_with(mock_tk_class.return_value)
+        # GameUI should be initialized with the instance returned by tk.Tk() and the game_manager instance
+        mock_game_ui_class.assert_called_once_with(mock_tk_class.return_value, game_manager)
         
         self.assertEqual(game_manager.root, mock_tk_class.return_value,
                          "GameManager's root is not the instance returned by tk.Tk mock.")
@@ -50,7 +50,7 @@ class TestGameManager(unittest.TestCase):
     @patch('game_engine.game_manager.setup_database')
     @patch('game_engine.game_manager.GameUI')
     @patch('game_engine.game_manager.tk.Tk')
-    def test_start_game_calls_ui_start_ui(self, mock_tk_class, mock_game_ui_class,
+    def test_start_game_calls_ui_start_ui(self, mock_tk_class, mock_game_ui_class, 
                                            mock_setup_database, mock_os_path_exists):
         """
         Tests if GameManager.start_game() correctly calls the ui's start_ui() method.
@@ -64,7 +64,7 @@ class TestGameManager(unittest.TestCase):
         mock_game_ui_class.return_value = mock_ui_instance
 
         # Instantiate GameManager
-        game_manager = GameManager()
+        game_manager = GameManager() # Instance to be passed
 
         # Call the method to test
         game_manager.start_game()
@@ -75,7 +75,58 @@ class TestGameManager(unittest.TestCase):
         # Also check that core init steps were still performed
         mock_setup_database.assert_called_once()
         mock_tk_class.assert_called_once()
-        mock_game_ui_class.assert_called_once_with(mock_tk_class.return_value)
+        mock_game_ui_class.assert_called_once_with(mock_tk_class.return_value, game_manager)
+
+    @patch('game_engine.game_manager.os.path.exists')
+    @patch('game_engine.game_manager.setup_database')
+    @patch('game_engine.game_manager.GameUI')
+    @patch('game_engine.game_manager.tk.Tk')
+    @patch('game_engine.game_manager.parse_input')
+    def test_process_player_command_with_input(self, mock_parse_input, mock_tk_class, 
+                                               mock_game_ui_class, mock_setup_database, 
+                                               mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        mock_ui_instance = MagicMock()
+        mock_game_ui_class.return_value = mock_ui_instance
+        
+        # Configure mock UI behavior
+        mock_ui_instance.get_player_input.return_value = "test command"
+        # Configure mock parse_input behavior
+        mock_parse_input.return_value = "parsed test command"
+
+        manager = GameManager()
+        manager.process_player_command()
+
+        mock_ui_instance.get_player_input.assert_called_once()
+        mock_parse_input.assert_called_once_with("test command")
+        
+        # Check calls to add_story_text
+        calls = mock_ui_instance.add_story_text.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0][0], 'You typed: test command') # first argument of first call
+        self.assertEqual(calls[1][0][0], 'The ancient echoes respond...') # first argument of second call
+
+    @patch('game_engine.game_manager.os.path.exists')
+    @patch('game_engine.game_manager.setup_database')
+    @patch('game_engine.game_manager.GameUI')
+    @patch('game_engine.game_manager.tk.Tk')
+    @patch('game_engine.game_manager.parse_input')
+    def test_process_player_command_empty_input(self, mock_parse_input, mock_tk_class, 
+                                                mock_game_ui_class, mock_setup_database, 
+                                                mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        mock_ui_instance = MagicMock()
+        mock_game_ui_class.return_value = mock_ui_instance
+
+        # Configure mock UI behavior for empty/whitespace input
+        mock_ui_instance.get_player_input.return_value = "   " 
+
+        manager = GameManager()
+        manager.process_player_command()
+
+        mock_ui_instance.get_player_input.assert_called_once()
+        mock_ui_instance.add_story_text.assert_not_called()
+        mock_parse_input.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- `game_engine/game_manager.py` (`GameManager`):
    - `__init__`: - Imports `parse_input` from `game_engine.input_parser`. - Passes `self` (the `GameManager` instance) to the `GameUI` constructor: `self.ui = GameUI(self.root, self)`.
    - New method `process_player_command(self)`:
        - Retrieves input string from `self.ui.get_player_input()`.
        - If input is not empty (after stripping):
            - Echoes the stripped command to story area: `self.ui.add_story_text(f'You typed: {stripped_command}')`.
            - Calls `parse_input(stripped_command)`. - Adds a placeholder response: `self.ui.add_story_text('The ancient echoes respond...')`.

- `ui/ui_manager.py` (`GameUI`):
    - `__init__`: - Signature changed to `__init__(self, root, game_manager_ref)`. - Stores `self.game_manager = game_manager_ref`.
    - `send_button` creation:
        - Its `command` option is now set to `self.game_manager.process_player_command`.
        - Includes a check for `self.game_manager` and `hasattr(self.game_manager, 'process_player_command')` before assignment, setting command to `None` if unavailable.

- Test Updates:
    - `tests/test_game_manager.py`: - `GameUI` mock in initialization tests updated to expect the `GameManager` instance as the second argument. - Added `test_process_player_command_with_input` and `test_process_player_command_empty_input` to verify new command processing logic, mocking UI methods and `parse_input`.
    - `tests/test_ui_manager.py`:
        - `setUp` updated to instantiate `GameUI` with a mock `GameManager` (which has a mock `process_player_command` attribute).
        - Verified that `send_button.cget('command')` is correctly set to the game manager's processing method. - Added `test_send_button_command_with_none_game_manager` to check behavior when `GameUI` is initialized with `game_manager_ref=None`.