### PR TITLE
feat: Integrate dynamic AI responses into GameManager command loop

### DIFF
--- a/game_engine/game_manager.py
+++ b/game_engine/game_manager.py
@@ -85,8 +85,12 @@ class GameManager:
             # Placeholder for actual command processing logic
             # For now, just acknowledge the parsed command (which is same as stripped_command)
             # self.ui.add_story_text(f'Parsed as: {parsed_command}') # Optional debug line
-            
-            self.ui.add_story_text('The ancient echoes respond...')
+
+            # Get AI response to the player's command
+            # For now, we are not passing any specific context beyond the default
+            # This could be expanded to include recent story text or game state.
+            ai_response = self.ai_dm.get_ai_response(player_action=parsed_command)
+            self.ui.add_story_text(ai_response)
         # else:
             # Optionally, handle empty input, e.g., self.ui.add_story_text("Please enter a command.")
             # For now, empty input is silently ignored as per the conditional check.


### PR DESCRIPTION
- Modified `GameManager.process_player_command` in `game_engine/game_manager.py`:
    - Replaced the placeholder response `self.ui.add_story_text('The ancient echoes respond...')`.
    - Now calls `self.ai_dm.get_ai_response(player_action=parsed_command)` to get a dynamic response from the AI Dungeon Master.
    - Adds the AI's response to the UI story area using `self.ui.add_story_text(ai_response)`.
    - The `player_action` is the (currently simply stripped) command from you.
    - Uses the default `current_context` from `AIDungeonMaster.get_ai_response`.

- Updated `tests/test_game_manager.py` for `process_player_command`:
    - In `test_process_player_command_with_input`: - Configured the mock `AIDungeonMaster` instance (`manager.ai_dm`) to return a specific test string for `get_ai_response`. - Verified that `manager.ai_dm.get_ai_response` is called with the correct `player_action`. - Updated assertions for `manager.ui.add_story_text` to check for two calls: one for echoing your input and the second for displaying the AI's dynamic response, verifying order and content.
    - In `test_process_player_command_empty_input`:
        - Added an assertion to ensure `manager.ai_dm.get_ai_response` is not called when the input is empty.