### PR TITLE
fix: Resolve model name conflict to use gemini-2.0-flash-lite

### DIFF
--- a/game_engine/ai_dm_interface.py
+++ b/game_engine/ai_dm_interface.py
@@ -94,9 +94,8 @@ if __name__ == '__main__':
             dm = AIDungeonMaster() # API key loaded from environment
             print("AIDungeonMaster initialized successfully.")
 
-            
+            # Updated check for the new model name
             if "gemini-2.0-flash-lite" in dm.model.model_name:
-
                  print(f"Successfully initialized model: {dm.model.model_name}")
             else:
                  print(f"Model name unexpected: {dm.model.model_name}")

--- a/tests/test_ai_dm_interface.py
+++ b/tests/test_ai_dm_interface.py
@@ -20,7 +20,7 @@ class TestAIDungeonMaster(unittest.TestCase):
         """
         dm = AIDungeonMaster(api_key='direct_test_key')
         mock_genai.configure.assert_called_once_with(api_key='direct_test_key')
-        mock_genai.GenerativeModel.assert_called_once_with('gemini-1.5-flash-latest')
+        mock_genai.GenerativeModel.assert_called_once_with('gemini-2.0-flash-lite')
         self.assertEqual(dm.model, mock_genai.GenerativeModel.return_value)
 
     @patch('game_engine.ai_dm_interface.os.getenv')
@@ -33,7 +33,7 @@ class TestAIDungeonMaster(unittest.TestCase):
         dm = AIDungeonMaster() # No api_key argument
         mock_os_getenv.assert_called_once_with("GOOGLE_API_KEY")
         mock_genai.configure.assert_called_once_with(api_key='env_test_key')
-        mock_genai.GenerativeModel.assert_called_once_with('gemini-1.5-flash-latest')
+        mock_genai.GenerativeModel.assert_called_once_with('gemini-2.0-flash-lite')
         self.assertEqual(dm.model, mock_genai.GenerativeModel.return_value)
 
     @patch('game_engine.ai_dm_interface.os.getenv')


### PR DESCRIPTION
- I updated `AIDungeonMaster.__init__` in `game_engine/ai_dm_interface.py` to initialize the model with `genai.GenerativeModel('gemini-2.0-flash-lite')`.
- I updated the `if __name__ == '__main__':` example block in `game_engine/ai_dm_interface.py` to correctly check for the model name "gemini-2.0-flash-lite".
- I updated unit tests in `tests/test_ai_dm_interface.py` for `AIDungeonMaster.__init__` to assert that `genai.GenerativeModel` is called with 'gemini-2.0-flash-lite'.

This resolves the merge conflict caused by differing model names.