### PR TITLE
feat: Add current_location and story_flags to players table

### DIFF
--- a/game_engine/persistence_service.py
+++ b/game_engine/persistence_service.py
@@ -21,7 +21,9 @@ def setup_database(db_path='data/rpg_save.db'):
                 hp INTEGER,
                 max_hp INTEGER,
                 mp INTEGER,
-                max_mp INTEGER
+                max_mp INTEGER,
+                current_location TEXT,
+                story_flags TEXT
             )
         ''')
 

--- a/tests/test_persistence_service.py
+++ b/tests/test_persistence_service.py
@@ -95,6 +95,8 @@ class TestPersistenceService(unittest.TestCase):
             'max_hp': {'type': 'INTEGER', 'notnull': 0, 'pk': 0},
             'mp': {'type': 'INTEGER', 'notnull': 0, 'pk': 0},
             'max_mp': {'type': 'INTEGER', 'notnull': 0, 'pk': 0},
+            'current_location': {'type': 'TEXT', 'notnull': 0, 'pk': 0},
+            'story_flags': {'type': 'TEXT', 'notnull': 0, 'pk': 0},
         }
 
         self.assertEqual(len(columns_info), len(expected_schema),


### PR DESCRIPTION
- I modified `setup_database` in `game_engine/persistence_service.py`:
    - I updated the `CREATE TABLE IF NOT EXISTS players` SQL statement.
    - I added new columns:
        - `current_location TEXT`
        - `story_flags TEXT` (intended to store JSON string)

- I updated `test_players_table_schema` in `tests/test_persistence_service.py`:
    - I modified the expected schema to include `current_location` and `story_flags`.
    - I added assertions to verify the presence and correct type (`TEXT`) of these new columns.