### PR TITLE
fix: Add preventDefault to Enter key and debug logs for command sending

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -299,6 +299,7 @@ async function handleMapClick(event) {
 
 // --- Function to send command to Python ---
 async function sendCommand() {
+    console.log("JS DEBUG: sendCommand() function execution started.");
     const commandInput = document.getElementById('commandInput');
     const command = commandInput.value.trim();
     if (command) {
@@ -311,14 +312,17 @@ async function sendCommand() {
         }
         commandInput.value = ''; // Clear input field
     }
+    console.log("JS DEBUG: sendCommand() function execution finished.");
 }
 
 // --- Initialization and Event Listeners ---
 document.addEventListener('DOMContentLoaded', (event) => {
     const commandInput = document.getElementById('commandInput');
     if(commandInput) {
-        commandInput.addEventListener('keypress', function (e) {
+        commandInput.addEventListener('keypress', function (e) { // 'e' is the event object
             if (e.key === 'Enter') {
+                console.log("JS DEBUG: Enter key pressed in commandInput, attempting to call sendCommand(). Event type: " + e.type);
+                e.preventDefault();
                 sendCommand();
             }
         });
@@ -326,7 +330,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
     const sendCmdButton = document.getElementById('sendCommandButton');
     if (sendCmdButton) {
-        sendCmdButton.addEventListener('click', sendCommand);
+        sendCmdButton.addEventListener('click', function(event) { // Wrap to access event
+            console.log("JS DEBUG: SendCommandButton clicked, attempting to call sendCommand(). Event type: " + event.type);
+            sendCommand();
+        });
     }
 
     const gameMapElement = document.getElementById('gameMap');


### PR DESCRIPTION
This commit addresses a potential source of double command submission and adds extensive logging to further diagnose the issue.

1.  **`web/script.js`:**
    *   Modified the `keypress` event listener for the command input field (`#commandInput`):
        *   Added `e.preventDefault()` when the 'Enter' key is pressed to stop any default browser actions that might interfere with command submission.
    *   Added `console.log` statements for debugging:
        *   In the 'Enter' key listener callback, before calling `sendCommand()`.
        *   In the 'click' event listener callback for `#sendCommandButton`, before calling `sendCommand()`.
        *   At the very beginning of the `sendCommand()` function.
        *   At the very end of the `sendCommand()` function.
    *   The 'click' event listener for `#sendCommandButton` was wrapped in an anonymous function to allow access to the `event` object for logging.

These changes aim to prevent one potential cause of multiple submissions and provide detailed tracing of the `sendCommand` function's invocation.