### PR TITLE
fix: Clear command input early in sendCommand to prevent double send

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -302,15 +302,20 @@ async function sendCommand() {
     console.log("JS DEBUG: sendCommand() function execution started.");
     const commandInput = document.getElementById('commandInput');
     const command = commandInput.value.trim();
+
     if (command) {
-        update_narrative(command, 'player_command'); // Display player's command
+        const commandToProcess = command; // Store it before clearing
+        commandInput.value = ''; // Clear input field EARLY
+        console.log("JS DEBUG: Input field cleared. Command to process: " + commandToProcess);
+
+        update_narrative(commandToProcess, 'player_command');
         try {
-            await eel.process_player_command_py(command)(); // Call Python
+            await eel.process_player_command_py(commandToProcess)();
         } catch (error) {
             console.error("JS: Error calling process_player_command_py:", error);
-            update_narrative("Error: Could not send command to Python. " + error);
+            // Using 'system' type for errors, or keep as default 'normal'
+            update_narrative("Error: Could not send command to Python. " + error, 'system');
         }
-        commandInput.value = ''; // Clear input field
     }
     console.log("JS DEBUG: sendCommand() function execution finished.");
 }


### PR DESCRIPTION
This commit refactors the `sendCommand` JavaScript function in `web/script.js`.

- The command input field (`commandInput.value = '';`) is now cleared immediately after the command string is retrieved and trimmed, and before `update_narrative` or the Eel call to Python is made.
- This change is intended to prevent a potential issue where DOM manipulation or focus changes related to `update_narrative` might have been indirectly re-triggering the send command logic when the send button was clicked.
- Added a console log after clearing the input to show the command being processed.
- Changed error messages sent to `update_narrative` in the `catch` block to use the 'system' type.